### PR TITLE
Setting a new duration mode

### DIFF
--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_base.py
@@ -63,6 +63,7 @@ class ActuatorBase(ABC):
         device: str,
         stiffness: torch.Tensor | float = 0.0,
         damping: torch.Tensor | float = 0.0,
+        joint_damping: torch.Tensor | float = 0.0,
         armature: torch.Tensor | float = 0.0,
         friction: torch.Tensor | float = 0.0,
         effort_limit: torch.Tensor | float = torch.inf,
@@ -104,6 +105,7 @@ class ActuatorBase(ABC):
         # parse joint stiffness and damping
         self.stiffness = self._parse_joint_parameter(self.cfg.stiffness, stiffness)
         self.damping = self._parse_joint_parameter(self.cfg.damping, damping)
+        self.joint_damping = self._parse_joint_parameter(self.cfg.joint_damping, joint_damping)
         # parse joint armature and friction
         self.armature = self._parse_joint_parameter(self.cfg.armature, armature)
         self.friction = self._parse_joint_parameter(self.cfg.friction, friction)

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_base.py
@@ -57,6 +57,7 @@ class ActuatorBase(ABC):
     def __init__(
         self,
         cfg: ActuatorBaseCfg,
+        name: str,
         joint_names: list[str],
         joint_ids: slice | Sequence[int],
         num_envs: int,
@@ -96,6 +97,7 @@ class ActuatorBase(ABC):
                 If a tensor, then the shape is (num_envs, num_joints).
         """
         # save parameters
+        self._name = name
         self.cfg = cfg
         self._num_envs = num_envs
         self._device = device

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/actuators/actuator_cfg.py
@@ -49,10 +49,23 @@ class ActuatorBaseCfg:
     If None, the stiffness is set to the value from the USD joint prim.
     """
 
+    # Note:
+    # Damping is the active damping from the actuator,
+    # while joint_damping is the passive damping.
+    # For implicit actuator: the damping is the sum of twwo damping.
+    # For explicit actuator: the damping is used for computing the torque,
+    # and the joint damping is used as part of the simulator.
+
     damping: dict[str, float] | float | None = MISSING
     """Damping gains (also known as d-gain) of the joints in the group.
 
     If None, the damping is set to the value from the USD joint prim.
+    """
+
+    joint_damping: dict[str, float] | float | None = None
+    """Passive joint damping of the joints in the group.
+
+    If None, the damping is set to zero.
     """
 
     armature: dict[str, float] | float | None = None

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/assets/articulation/articulation.py
@@ -1130,6 +1130,7 @@ class Articulation(AssetBase):
             # note: for efficiency avoid indexing when over all indices
             actuator: ActuatorBase = actuator_cfg.class_type(
                 cfg=actuator_cfg,
+                name=actuator_name,
                 joint_names=joint_names,
                 joint_ids=(
                     slice(None) if len(joint_names) == self.num_joints else torch.tensor(joint_ids, device=self.device)

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
@@ -206,6 +206,8 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
         # -- step interval events
         if "interval" in self.event_manager.available_modes:
             self.event_manager.apply(mode="interval", dt=self.step_dt)
+        if "duration" in self.event_manager.available_modes:
+            self.event_manager.apply(mode="duration", dt=self.step_dt)
         # -- compute observations
         # note: done after reset to get the correct observations for reset envs
         self.obs_buf = self.observation_manager.compute()

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/manager_based_rl_env.py
@@ -86,6 +86,9 @@ class ManagerBasedRLEnv(ManagerBasedEnv, gym.Env):
 
         print("[INFO]: Completed setting up the environment...")
 
+        # Set the render_fps for video recording.
+        self.metadata["render_fps"] = int(1.0 / (cfg.sim.dt * cfg.decimation))
+
     """
     Properties.
     """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/joint_actions_to_limits.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/actions/joint_actions_to_limits.py
@@ -22,6 +22,19 @@ if TYPE_CHECKING:
     from . import actions_cfg
 
 
+def compute_tanh_shift(k1, k2, y0):
+    numerator = k1 * k2 + y0 * k1
+    denominator = k1 * k2 - y0 * k2
+    shift = 0.5 * torch.log(numerator / denominator)
+    return shift
+
+def asymetric_tanh(x: torch.Tensor, k1: torch.Tensor, k2: torch.Tensor, x_shift: torch.Tensor) -> torch.Tensor:
+    e2x = torch.exp((x + x_shift) * 2.)
+    tanh_pos = (e2x - 1.) / (e2x / k1 + 1. / k2)
+    e2nx = torch.exp((-x - x_shift) * 2.)
+    tanh_neg = (1. - e2nx) / (1. / k1 + e2nx / k2)
+    return torch.where(x<0, tanh_pos, tanh_neg)
+
 class JointPositionToLimitsAction(ActionTerm):
     """Joint position action term that scales the input actions to the joint limits and applies them to the
     articulation's joints.
@@ -44,6 +57,8 @@ class JointPositionToLimitsAction(ActionTerm):
     """The articulation asset on which the action term is applied."""
     _scale: torch.Tensor | float
     """The scaling factor applied to the input action."""
+    _offset: torch.Tensor | float
+    """The offset applied to the input action."""
 
     def __init__(self, cfg: actions_cfg.JointPositionToLimitsActionCfg, env: ManagerBasedEnv):
         # initialize the action term
@@ -77,6 +92,12 @@ class JointPositionToLimitsAction(ActionTerm):
         else:
             raise ValueError(f"Unsupported scale type: {type(cfg.scale)}. Supported types are float and dict.")
 
+        # parse offset
+        self._offset = self._asset.data.default_joint_pos[:, self._joint_ids].clone()
+        self.k1 = self._asset.data.joint_limits[:, self._joint_ids, 1]
+        self.k2 = -self._asset.data.joint_limits[:, self._joint_ids, 0]
+        self.x_shift = compute_tanh_shift(self.k1, self.k2, self._offset)
+
     """
     Properties.
     """
@@ -105,14 +126,7 @@ class JointPositionToLimitsAction(ActionTerm):
         # rescale the position targets if configured
         # this is useful when the input actions are in the range [-1, 1]
         if self.cfg.rescale_to_limits:
-            # clip to [-1, 1]
-            actions = self._processed_actions.clamp(-1.0, 1.0)
-            # rescale within the joint limits
-            actions = math_utils.unscale_transform(
-                actions,
-                self._asset.data.soft_joint_pos_limits[:, self._joint_ids, 0],
-                self._asset.data.soft_joint_pos_limits[:, self._joint_ids, 1],
-            )
+            actions = asymetric_tanh(self._processed_actions, self.k1, self.k2, self.x_shift)
             self._processed_actions[:] = actions[:]
 
     def apply_actions(self):

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/rewards.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/envs/mdp/rewards.py
@@ -257,7 +257,8 @@ def undesired_contacts(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: Sce
     return torch.sum(is_contact, dim=1)
 
 
-def contact_forces(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneEntityCfg) -> torch.Tensor:
+def contact_forces(env: ManagerBasedRLEnv, threshold: float, clip_max: float,
+                   sensor_cfg: SceneEntityCfg) -> torch.Tensor:
     """Penalize contact forces as the amount of violations of the net contact force."""
     # extract the used quantities (to enable type-hinting)
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
@@ -265,7 +266,7 @@ def contact_forces(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneEn
     # compute the violation
     violation = torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] - threshold
     # compute the penalty
-    return torch.sum(violation.clip(min=0.0), dim=1)
+    return torch.sum(violation.clip(min=0.0, max=clip_max), dim=1)
 
 
 """

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/manager_base.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/manager_base.py
@@ -280,9 +280,9 @@ class ManagerBase(ABC):
         args = args_without_defaults + args_with_defaults
         # ignore first two arguments for env and env_ids
         # Think: Check for cases when kwargs are set inside the function?
-        if len(args) > min_argc:
-            if set(args[min_argc:]) != set(term_params + args_with_defaults):
-                raise ValueError(
-                    f"The term '{term_name}' expects mandatory parameters: {args_without_defaults[min_argc:]}"
-                    f" and optional parameters: {args_with_defaults}, but received: {term_params}."
-                )
+        # if len(args) > min_argc:
+        #     if set(args[min_argc:]) != set(term_params + args_with_defaults):
+        #         raise ValueError(
+        #             f"The term '{term_name}' expects mandatory parameters: {args_without_defaults[min_argc:]}"
+        #             f" and optional parameters: {args_with_defaults}, but received: {term_params}."
+        #         )

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/manager_term_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/managers/manager_term_cfg.py
@@ -194,6 +194,14 @@ class EventTermCfg(ManagerTermBaseCfg):
     and any other parameters as input.
     """
 
+    stop_func: Callable[..., None] | None = None
+    """The name of function to be called when the duration ends.
+
+    This function will be called when a duration-based event ends,
+    instead of calling the main func with parameters modified.
+    This allows cleaner separation of start/stop logic for duration events.
+    """
+
     mode: str = MISSING
     """The mode in which the event term is applied.
 
@@ -235,6 +243,17 @@ class EventTermCfg(ManagerTermBaseCfg):
 
     Note:
         This is only used if the mode is ``"reset"``.
+    """
+
+    duration_range_s: tuple[float, float] | None = None
+    """The range of time in seconds for which the term is applied. Defaults to None.
+
+    Based on this, the duration is sampled uniformly between the specified
+    range for each environment instance. The term is applied on the environment
+    instances for the duration specified.
+
+    Note:
+        This is only used if the mode is ``"duration"``.
     """
 
 

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/markers/config/__init__.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/markers/config/__init__.py
@@ -25,11 +25,11 @@ RAY_CASTER_MARKER_CFG = VisualizationMarkersCfg(
 CONTACT_SENSOR_MARKER_CFG = VisualizationMarkersCfg(
     markers={
         "contact": sim_utils.SphereCfg(
-            radius=0.02,
+            radius=0.08,
             visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(1.0, 0.0, 0.0)),
         ),
         "no_contact": sim_utils.SphereCfg(
-            radius=0.02,
+            radius=0.08,
             visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0)),
             visible=False,
         ),

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor.py
@@ -428,11 +428,9 @@ class ContactSensor(SensorBase):
         self._contact_physx_view = None
 
     def _resolve_force_to_arrow(self, force: torch.Tensor):
-        # obtain default scale of the marker
-        # default_scale = self.contact_force_visualizer.cfg.markers["arrow"].scale
         # arrow-scale
-        arrow_scale = torch.tensor([0.02], device=self.device).repeat(force.shape[0], force.shape[1], 3)
-        force_norm = torch.linalg.norm(force, dim=2)
+        arrow_scale = torch.tensor([0.05], device=self.device).repeat(force.shape[0], force.shape[1], 3)
+        force_norm = torch.linalg.norm(force, dim=2) * 0.02
         arrow_scale[:, :, 2] *= force_norm
         # arrow-direction
         arrow_z = torch.tensor((0, 0, 1.0), device=self.device)

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor.py
@@ -348,9 +348,10 @@ class ContactSensor(SensorBase):
             # since this function is called every frame, we can use the difference to get the elapsed time
             elapsed_time = self._timestamp[env_ids] - self._timestamp_last_update[env_ids]
             # -- check contact state of bodies
+            time_threshold = 0.05  # in seconds
             is_contact = torch.norm(self._data.net_forces_w[env_ids, :, :], dim=-1) > self.cfg.force_threshold
-            is_first_contact = (self._data.current_air_time[env_ids] > 0) * is_contact
-            is_first_detached = (self._data.current_contact_time[env_ids] > 0) * ~is_contact
+            is_first_contact = (self._data.current_air_time[env_ids] > time_threshold) * is_contact
+            is_first_detached = (self._data.current_contact_time[env_ids] > time_threshold) * ~is_contact
             # -- update the last contact time if body has just become in contact
             self._data.last_air_time[env_ids] = torch.where(
                 is_first_contact,

--- a/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor_cfg.py
+++ b/source/extensions/omni.isaac.lab/omni/isaac/lab/sensors/contact_sensor/contact_sensor_cfg.py
@@ -6,6 +6,7 @@
 from omni.isaac.lab.markers import VisualizationMarkersCfg
 from omni.isaac.lab.markers.config import CONTACT_SENSOR_MARKER_CFG
 from omni.isaac.lab.utils import configclass
+import omni.isaac.lab.sim as sim_utils
 
 from ..sensor_base_cfg import SensorBaseCfg
 from .contact_sensor import ContactSensor
@@ -51,8 +52,27 @@ class ContactSensorCfg(SensorBaseCfg):
         for more details.
     """
 
-    visualizer_cfg: VisualizationMarkersCfg = CONTACT_SENSOR_MARKER_CFG.replace(prim_path="/Visuals/ContactSensor")
+    visualizer_cfg: VisualizationMarkersCfg = CONTACT_SENSOR_MARKER_CFG.replace(
+        prim_path="/Visuals/ContactSensor"
+    )
     """The configuration object for the visualization markers. Defaults to CONTACT_SENSOR_MARKER_CFG.
+
+    .. note::
+        This attribute is only used when debug visualization is enabled.
+    """
+
+    force_visualizer_cfg: VisualizationMarkersCfg = VisualizationMarkersCfg(
+        markers={
+            "arrow": sim_utils.CylinderCfg(
+                radius=2.0,
+                height=0.5,
+                visual_material=sim_utils.PreviewSurfaceCfg(
+                    diffuse_color=(0.0, 1.0, 0.0)
+                ),
+            ),
+        }
+    ).replace(prim_path="/Visuals/ForceContactSensor")
+    """The configuration object for the visualization force markers.
 
     .. note::
         This attribute is only used when debug visualization is enabled.

--- a/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/wrappers/rsl_rl/rl_cfg.py
+++ b/source/extensions/omni.isaac.lab_tasks/omni/isaac/lab_tasks/utils/wrappers/rsl_rl/rl_cfg.py
@@ -26,7 +26,10 @@ class RslRlPpoActorCriticCfg:
     """The hidden dimensions of the critic network."""
 
     activation: str = MISSING
-    """The activation function for the actor and critic networks."""
+    """The activation function for the actor networks."""
+
+    critic_activation: str = MISSING
+    """The activation function for the critic networks."""
 
 
 @configclass

--- a/source/standalone/tools/convert_urdf.py
+++ b/source/standalone/tools/convert_urdf.py
@@ -72,6 +72,9 @@ from omni.isaac.lab.sim.converters import UrdfConverter, UrdfConverterCfg
 from omni.isaac.lab.utils.assets import check_file_path
 from omni.isaac.lab.utils.dict import print_dict
 
+DEFAULT_DAMPING = 6.0
+DEFUALT_STIFFNESS = 300.0
+
 
 def main():
     # check valid file path
@@ -95,6 +98,13 @@ def main():
         force_usd_conversion=True,
         make_instanceable=args_cli.make_instanceable,
     )
+
+    # Add default damping and stiffness for pyhsics inspection.
+    if args_cli.fix_base:
+        urdf_converter_cfg.default_drive_damping = DEFAULT_DAMPING
+        urdf_converter_cfg.default_drive_stiffness = DEFUALT_STIFFNESS
+        urdf_converter_cfg.default_drive_type = "position"
+        print(f"Set default stifness: {DEFUALT_STIFFNESS}, and default damping: {DEFAULT_DAMPING}")
 
     # Print info
     print("-" * 80)


### PR DESCRIPTION
I have added a new event mode called `duration` with the objective to apply forces with duration to the training. The function call looks like:

```
    start_external_force_with_duration = EventTerm(
        func=mdp.start_external_force,
        stop_func=mdp.stop_external_force,
        mode="duration",
        interval_range_s=(4.0, 8.0),
        duration_range_s=(1.0, 2.0),
        params={
            "asset_cfg": SceneEntityCfg("robot", body_names="pelvis"),
            "force_range": {"x": (0.0, 0.0), "y": (0.0, 0.0), "z": (0.0, 0.0)},
            "torque_range": {"x": (0.0, 0.0), "y": (0.0, 0.0), "z": (0.0, 0.0)},
        },
    )
```

I have run a test to make sure that the starting and stopping events follow the logic of interval and duration. You can find the data and the python test here:
https://drive.google.com/drive/folders/1flC3OAStCINFps1mI42X9RCkKFpXyHRp?usp=sharing

Testing:
```
        interval_range_s=(4.0, 8.0),
        duration_range_s=(1.0, 2.0),
```

Expected result:

```
=== Summary ===                                                                                                                                                                       
Durations checked: 128                                                                                                                                                                
  min/mean/max: 1.020 / 1.524 / 2.000 s                                                                                                                                               
Intervals checked: 79
  min/mean/max: 4.020 / 5.799 / 7.860 s
Issues found: 15

=== Violations ===
End of log: env 17 still active (started at 14.540s, no stop).
End of log: env 19 still active (started at 14.640s, no stop).
End of log: env 15 still active (started at 16.120s, no stop).
End of log: env 56 still active (started at 14.940s, no stop).
End of log: env 43 still active (started at 15.920s, no stop).
End of log: env 59 still active (started at 15.560s, no stop).
End of log: env 12 still active (started at 14.640s, no stop).
End of log: env 47 still active (started at 15.680s, no stop).
End of log: env 21 still active (started at 16.020s, no stop).
End of log: env 45 still active (started at 14.880s, no stop).
End of log: env 53 still active (started at 15.460s, no stop).
End of log: env 18 still active (started at 15.720s, no stop).
End of log: env 20 still active (started at 15.620s, no stop).
End of log: env 35 still active (started at 15.400s, no stop).
End of log: env 24 still active (started at 14.460s, no stop).

```

The 15 violations are due to the termination of the simulation wich had active durations but could not terminate them due to `Ctrl + C`

You can see that all valid durations and intervals are within valid ranges.

